### PR TITLE
Migrate controls to VisualState.

### DIFF
--- a/Shell.Controls/AppListLayoutControl.xaml.cs
+++ b/Shell.Controls/AppListLayoutControl.xaml.cs
@@ -1,24 +1,12 @@
 ﻿using Microsoft.Toolkit.Uwp.UI.Controls;
-using Shell.LiveTilesAccessLibrary;
 using Shell.Models;
 using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Controls.Primitives;
-using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Input;
-using Windows.UI.Xaml.Media;
-using Windows.UI.Xaml.Navigation;
-
-// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
 
 namespace Shell.Controls {
     public sealed partial class AppListLayoutControl : UserControl {

--- a/Shell.Controls/StartScreenControl.xaml
+++ b/Shell.Controls/StartScreenControl.xaml
@@ -8,6 +8,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:media="using:Windows.UI.Xaml.Media"
+    xmlns:triggers="using:Microsoft.Toolkit.Uwp.UI.Triggers"
     mc:Ignorable="d"
     d:DesignHeight="1080"
     d:DesignWidth="1920"
@@ -23,12 +24,8 @@
             x:Name="RootScroll"
             HorizontalSnapPointsType="MandatorySingle"
             VerticalSnapPointsType="MandatorySingle"
-            HorizontalScrollBarVisibility="Visible"
-            HorizontalScrollMode="Enabled"
             ViewChanging="ScrollViewer_ViewChanging">
-            <StackPanel
-                x:Name="Start"
-                Orientation="Horizontal">
+            <StackPanel x:Name="Start">
                 <Grid x:Name="StartScreenLayout">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
@@ -178,5 +175,64 @@
                 </Grid>
             </StackPanel>
         </ScrollViewer>
+
+        <VisualStateManager.VisualStateGroups>
+            <VisualStateGroup x:Name="ControlSizeStates">
+                <VisualState>
+                    <VisualState.StateTriggers>
+                        <triggers:ControlSizeTrigger MinWidth="950" TargetElement="{x:Bind Path=Root}" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="Start.Orientation" Value="Vertical" />
+                        <Setter Target="Apps.Orientation" Value="Vertical" />
+
+                        <!--<Setter Target="StartHeaderToolbar.Padding" Value="15,0" />
+                        <Setter Target="StartFooterToolbar.Padding" Value="15,0" />
+                        <Setter Target="AppsHeaderToolbar.Padding" Value="15,0" />
+                        <Setter Target="AppsFooterToolbar.Padding" Value="15,0" />-->
+
+                        <Setter Target="StartScreenLayout.Height" Value="{x:Bind ScreenHeight}" />
+                        <Setter Target="StartScreenLayout.Width" Value="Auto" />
+                        <Setter Target="AppsScreenLayout.Height" Value="{x:Bind ScreenHeight}" />
+                        <Setter Target="AppsScreenLayout.Width" Value="Auto" />
+
+                        <Setter Target="RootScroll.HorizontalScrollMode" Value="Disabled" />
+                        <Setter Target="RootScroll.HorizontalScrollBarVisibility" Value="Disabled" />
+                        <Setter Target="RootScroll.HorizontalSnapPointsType" Value="None" />
+                        
+                        <Setter Target="RootScroll.VerticalScrollMode" Value="Enabled" />
+                        <Setter Target="RootScroll.VerticalScrollBarVisibility" Value="Auto" />
+                        <Setter Target="RootScroll.VerticalSnapPointsType" Value="MandatorySingle" />
+                    </VisualState.Setters>
+                </VisualState>
+                <VisualState>
+                    <VisualState.StateTriggers>
+                        <triggers:ControlSizeTrigger MinWidth="0" TargetElement="{x:Bind Path=Root}" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="Start.Orientation" Value="Horizontal" />
+                        <Setter Target="Apps.Orientation" Value="Horizontal" />
+
+                        <Setter Target="StartHeaderToolbar.Padding" Value="0" />
+                        <Setter Target="StartFooterToolbar.Padding" Value="0" />
+                        <Setter Target="AppsHeaderToolbar.Padding" Value="0" />
+                        <Setter Target="AppsFooterToolbar.Padding" Value="0" />
+
+                        <Setter Target="StartScreenLayout.Height" Value="Auto" />
+                        <Setter Target="StartScreenLayout.Width" Value="{x:Bind ScreenWidth}" />
+                        <Setter Target="AppsScreenLayout.Height" Value="Auto" />
+                        <Setter Target="AppsScreenLayout.Width" Value="{x:Bind ScreenWidth}" />
+                        
+                        <Setter Target="RootScroll.HorizontalScrollMode" Value="Enabled" />
+                        <Setter Target="RootScroll.HorizontalScrollBarVisibility" Value="Auto" />
+                        <Setter Target="RootScroll.HorizontalSnapPointsType" Value="MandatorySingle" />
+                        
+                        <Setter Target="RootScroll.VerticalScrollMode" Value="Disabled" />
+                        <Setter Target="RootScroll.VerticalScrollBarVisibility" Value="Disabled" />
+                        <Setter Target="RootScroll.VerticalSnapPointsType" Value="None" />
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+        </VisualStateManager.VisualStateGroups>
     </Grid>
 </UserControl>

--- a/Shell.Controls/StartScreenControl.xaml.cs
+++ b/Shell.Controls/StartScreenControl.xaml.cs
@@ -21,8 +21,8 @@ namespace Shell.Controls {
         public Action OnSettings { get; set; }
         public Action OnFocusLost { get; set; }
         public BitmapImage Wallpaper { get; set; }
-        public Double ScreenWidth;
-        public Double ScreenHeight;
+        public Double ScreenWidth = 1920;
+        public Double ScreenHeight = 1080;
 
         public StartScreenControl() {
             this.InitializeComponent();
@@ -78,35 +78,7 @@ namespace Shell.Controls {
         }
 
         private void Control_SizeChanged(Object sender, SizeChangedEventArgs e) {
-            this.LiveTilesLayout.ScreenHeight = this.ScreenHeight;
-            this.LiveTilesLayout.ScreenWidth = this.ScreenWidth;
-            this.AppsListLayout.ScreenHeight = this.ScreenHeight;
-            this.AppsListLayout.ScreenWidth = this.ScreenWidth;
-
             if (this.ScreenWidth <= 950) {
-                this.StartHeaderToolbar.Padding = new Thickness(0);
-                this.StartFooterToolbar.Padding = new Thickness(0);
-                this.AppsHeaderToolbar.Padding = new Thickness(0);
-                this.AppsFooterToolbar.Padding = new Thickness(0);
-
-                this.StartScreenLayout.Height = Double.NaN;
-                this.StartScreenLayout.Width = this.ScreenWidth;
-                this.AppsScreenLayout.Height = Double.NaN;
-                this.AppsScreenLayout.Width = this.ScreenWidth;
-
-                this.StartScreenLayout.HorizontalAlignment = HorizontalAlignment.Stretch;
-                this.StartScreenLayout.VerticalAlignment = VerticalAlignment.Stretch;
-                this.AppsListLayout.HorizontalAlignment = HorizontalAlignment.Stretch;
-                this.AppsListLayout.VerticalAlignment = VerticalAlignment.Stretch;
-
-                this.RootScroll.HorizontalScrollMode = ScrollMode.Enabled;
-                this.RootScroll.VerticalScrollMode = ScrollMode.Disabled;
-                this.RootScroll.HorizontalScrollBarVisibility = ScrollBarVisibility.Auto;
-                this.RootScroll.VerticalScrollBarVisibility = ScrollBarVisibility.Disabled;
-                this.RootScroll.HorizontalSnapPointsType = SnapPointsType.MandatorySingle;
-                this.RootScroll.VerticalSnapPointsType = SnapPointsType.None;
-                this.Start.Orientation = Orientation.Horizontal;
-                this.Apps.Orientation = Orientation.Horizontal;
             } else {
                 Double padding = this.ScreenWidth * 0.025;
                 this.StartHeaderToolbar.Padding = new Thickness(padding, this.ScreenHeight * 0.05, padding, 0);
@@ -119,20 +91,6 @@ namespace Shell.Controls {
                 // Hack to make scrollbar work
                 this.AppsListLayout.Height = this.ScreenHeight - (this.AppsHeaderToolbar.ActualHeight + this.AppsFooterToolbar.ActualHeight + 50);
                 this.AppsListLayout.Width = this.ScreenWidth;
-
-                this.StartScreenLayout.HorizontalAlignment = HorizontalAlignment.Stretch;
-                this.StartScreenLayout.VerticalAlignment = VerticalAlignment.Stretch;
-                this.AppsListLayout.HorizontalAlignment = HorizontalAlignment.Stretch;
-                this.AppsListLayout.VerticalAlignment = VerticalAlignment.Stretch;
-
-                this.RootScroll.HorizontalScrollMode = ScrollMode.Disabled;
-                this.RootScroll.VerticalScrollMode = ScrollMode.Enabled;
-                this.RootScroll.HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled;
-                this.RootScroll.VerticalScrollBarVisibility = ScrollBarVisibility.Auto;
-                this.RootScroll.HorizontalSnapPointsType = SnapPointsType.None;
-                this.RootScroll.VerticalSnapPointsType = SnapPointsType.MandatorySingle;
-                this.Start.Orientation = Orientation.Vertical;
-                this.Apps.Orientation = Orientation.Vertical;
             }
 
             // Force update

--- a/Shell.Host/HostWindow.xaml.cs
+++ b/Shell.Host/HostWindow.xaml.cs
@@ -36,7 +36,7 @@ namespace Shell.Host {
             this.SplashWindow.Show();
 
             this.StartScreenWindow = new StartScreen() {
-                Topmost = Shell.Host.Features.StartScreenTopMost,
+                Topmost = Features.StartScreenTopMost,
                 ShowInTaskbar = false,
                 OnExit = this.OnExit,
                 OnSettings = this.OnSettings,
@@ -48,14 +48,14 @@ namespace Shell.Host {
             this.StartScreenWindow.Show();
 
             this.StatusBarWindow = new StatusBar() {
-                Topmost = Shell.Host.Features.StatusBarTopMost,
+                Topmost = Features.StatusBarTopMost,
                 ShowInTaskbar = false,
             };
             if (settings.EnableStatusBar)
                 this.StatusBarWindow.Show();
 
             this.ActionBarWindow = new ActionBar() {
-                Topmost = Shell.Host.Features.ActionBarTopMost,
+                Topmost = Features.ActionBarTopMost,
                 ShowInTaskbar = false
             };
             if (settings.EnableActionBar)


### PR DESCRIPTION
This is the proper way handle responsivness in UWP. We will
still have to implement a resize listener in HostWindow for
this to properly work.